### PR TITLE
Fix: Add Navigation Arrow for Tip Description (#80)

### DIFF
--- a/lib/presentation/atoms/check_box_atom.dart
+++ b/lib/presentation/atoms/check_box_atom.dart
@@ -7,11 +7,13 @@ class CheckBoxAtom extends StatefulWidget {
     this.text, {
     required this.callback,
     this.initialValue = false,
+    this.trailing,
   });
 
   final String text;
   final bool initialValue;
   final Function(bool) callback;
+  final Widget? trailing;
 
   @override
   State<CheckBoxAtom> createState() => _CheckBoxAtomState();
@@ -37,12 +39,16 @@ class _CheckBoxAtomState extends State<CheckBoxAtom> {
 
   @override
   Widget build(BuildContext context) {
-    return CheckboxListTile(
+    return ListTile(
       contentPadding: EdgeInsets.zero,
-      title: TextAtom(widget.text),
-      controlAffinity: ListTileControlAffinity.leading,
-      value: isChecked,
-      onChanged: onChange,
+      title: CheckboxListTile(
+        contentPadding: EdgeInsets.zero,
+        title: TextAtom(widget.text),
+        controlAffinity: ListTileControlAffinity.leading,
+        value: isChecked,
+        onChanged: onChange,
+      ),
+      trailing: widget.trailing,
     );
   }
 }

--- a/lib/presentation/atoms/check_box_atom.dart
+++ b/lib/presentation/atoms/check_box_atom.dart
@@ -2,18 +2,19 @@ import 'package:flutter/material.dart';
 import 'package:infinite_horizons/domain/vibration_controller.dart';
 import 'package:infinite_horizons/presentation/atoms/atoms.dart';
 
+
 class CheckBoxAtom extends StatefulWidget {
   const CheckBoxAtom(
     this.text, {
     required this.callback,
     this.initialValue = false,
-    this.trailing,
+    this.onIconPressed,
   });
 
   final String text;
   final bool initialValue;
   final Function(bool) callback;
-  final Widget? trailing;
+  final VoidCallback? onIconPressed;
 
   @override
   State<CheckBoxAtom> createState() => _CheckBoxAtomState();
@@ -48,7 +49,11 @@ class _CheckBoxAtomState extends State<CheckBoxAtom> {
         value: isChecked,
         onChanged: onChange,
       ),
-      trailing: widget.trailing,
+      trailing: widget.onIconPressed != null
+          ? IconButton(
+              onPressed: widget.onIconPressed,
+              icon: const Icon(Icons.arrow_forward),)
+          : null,
     );
   }
 }

--- a/lib/presentation/organisms/intro/tips_organism.dart
+++ b/lib/presentation/organisms/intro/tips_organism.dart
@@ -8,6 +8,7 @@ import 'package:infinite_horizons/domain/tip.dart';
 import 'package:infinite_horizons/presentation/atoms/atoms.dart';
 import 'package:infinite_horizons/presentation/molecules/molecules.dart';
 import 'package:infinite_horizons/presentation/pages/all_tips_page.dart';
+import 'package:infinite_horizons/presentation/pages/tip_information_page.dart';
 
 class TipsOrganism extends StatelessWidget {
   const TipsOrganism(this.studyType);
@@ -58,6 +59,13 @@ class TipsOrganism extends StatelessWidget {
                 tip.text,
                 callback: (value) => onCheckBox(tip.id, value),
                 initialValue: tip.selected,
+                trailing: IconButton(
+                    onPressed: () => Navigator.of(context).push(
+                          MaterialPageRoute(
+                            builder: (context) => TipInformationPage(tip),
+                          ),
+                        ),
+                    icon: const Icon(Icons.arrow_forward),),
               );
             },
             itemCount: beforeStudyTips.length,

--- a/lib/presentation/organisms/intro/tips_organism.dart
+++ b/lib/presentation/organisms/intro/tips_organism.dart
@@ -59,13 +59,11 @@ class TipsOrganism extends StatelessWidget {
                 tip.text,
                 callback: (value) => onCheckBox(tip.id, value),
                 initialValue: tip.selected,
-                trailing: IconButton(
-                    onPressed: () => Navigator.of(context).push(
-                          MaterialPageRoute(
-                            builder: (context) => TipInformationPage(tip),
-                          ),
-                        ),
-                    icon: const Icon(Icons.arrow_forward),),
+                onIconPressed: () => Navigator.of(context).push(
+                  MaterialPageRoute(
+                    builder: (context) => TipInformationPage(tip),
+                  ),
+                ),
               );
             },
             itemCount: beforeStudyTips.length,


### PR DESCRIPTION
### Changes:

- Implemented a navigation arrow icon that opens the Tip Description (#80) when clicked.

### Screenshots: 
![Simulator Screenshot - iPhone 15 Pro Max - 2024-05-28 at 12 19 38](https://github.com/guyluz11/infinite_horizons/assets/39937989/925e1498-11da-45d3-bf4d-d559a409a81e)
